### PR TITLE
Qi scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 $ cd dia
 $ make install
 ```
+or
+```shell
+$ raco pkg install 'https://github.com/drym-org/dia?path=dia#main'
+```
+(use `--clone dia` to install the package via a clone)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ $ cd evaluation/attribution
 $ racket synthesized.rkt
 ```
 
+Module languages to parse appraisal and antecedents trees are available via
+`#lang abe/attribution` and `#lang abe/antecedents`.
+
 ## Incorporating Adjustments
 
 When labor, capital or ideas inputs are modified to account for formerly left-out items, these "adjustments" could be incorporated by following these steps.

--- a/dia/antecedents.rkt
+++ b/dia/antecedents.rkt
@@ -1,0 +1,61 @@
+#lang racket
+
+(provide (rename-out [mb #%module-begin]) #%datum #%top #%top-interaction #%app)
+
+#| Module language for antecedents
+
+Format:
+  #lang abe/antecedents
+  ["path/to/ideas-appraisal.md" "path/to/antecedents.md"] => exported-attributions-id
+
+Meaning:
+
+- The ideas path is an "appraisal" tree. Roughly, markdown bulleted list in tree
+form, with bracketed percentags [N%] at the end of the line. The antecedents
+path is an "antecedents" tree of roughly the same shape where the leaves have
+comma-separated antecedents in place of percentages.
+- Validate appraisals.
+- Tally antecedents attributions.
+- Validate attributions.
+- Export (provide) the exported-attributions-id bound to the attributions.
+
+Technically, the shape of the antecedents tree doesn't matter, as long as the
+leaves have antecedents. But this has only been tested on antecedents trees.
+
+Future work: try swapping define-runtime-path for syntax/path-spec's
+resolve-path-spec.
+
+|#
+
+(require racket/runtime-path
+         syntax/parse/define
+         abe/dia
+         abe/tree-parser)
+
+(define-syntax-parse-rule
+  (mb [ideas:string antecedents:string] {~datum =>} export:id)
+  ;; Make sure runtime-path resolved like a require: from context of written
+  ;; module, not this module. Also, we have to wrap path in #%datum manually or
+  ;; suffer a "#%datum not bound in the transformer environment" error.
+  #:with runtime-path-define-ideas
+  (datum->syntax #'ideas (syntax-e #'(define-runtime-path ideas-p (#%datum . ideas))) #'ideas)
+  #:with runtime-path-define-antecdents
+  (datum->syntax #'antecedents (syntax-e #'(define-runtime-path antecdents-p (#%datum . antecedents))) #'antecedents)
+  (#%module-begin
+   (provide export)
+   runtime-path-define-ideas
+   runtime-path-define-antecdents
+   (define tree (read-idea-attribution-tree ideas-p))
+   (define antes (read-idea-antecedents-tree antecdents-p))
+   (unless (validate-appraisal tree)
+     (error 'validate-appraisal "bad appraisal: ~a" tree))
+   (define export (make-hash))
+   (define aux (make-hash))
+   (tally tree node-weight bump #:results aux)
+   (unless (validate-attributions aux)
+     (error 'validate-attributions "bad attributions: ~a" aux))
+   (attribute-antecedents aux antes export)
+   (unless (validate-attributions export)
+     (error 'validate-attributions "bad attributions: ~a" export))))
+
+(module reader syntax/module-reader abe/antecedents)

--- a/dia/attribution.rkt
+++ b/dia/attribution.rkt
@@ -1,0 +1,57 @@
+#lang racket
+
+(provide (rename-out [mb #%module-begin]) #%datum #%top #%top-interaction #%app)
+
+#| Module language for attributions
+
+Format:
+  #lang abe/attributions
+  "path/to/capital-or-labor-appraisal.md" => exported-attributions-id
+
+Meaning:
+
+- The path is an "appraisal" tree. Roughly, markdown bulleted list in tree form,
+with bracketed percentags [N%] at the end of the line.
+- Validate appraisals.
+- Tally attributions.
+- Validate attributions.
+- Export (provide) the exported-attributions-id bound to the attributions.
+
+To identify attributions, the first sequence of non-space characters after a
+bullet is used. For capital, this means that descriptive bullets without a
+project name should be given a faux project name.
+
+Additionally, a sequence of non-space characters followed by the text " and "
+and another sequence of non-space characters is considered an attributive "pair"
+and is attributed as a single unit, to account for teamwork. Groups of sizes
+larger than 2 are not yet supported.
+
+Future work: try swapping define-runtime-path for syntax/path-spec's
+resolve-path-spec.
+
+|#
+
+(require racket/runtime-path
+         syntax/parse/define
+         abe/dia
+         abe/tree-parser)
+
+(define-syntax-parse-rule
+  (mb path:string {~datum =>} export:id)
+  ;; Make sure runtime-path resolved like a require: from context of written
+  ;; module, not this module. Also, we have to wrap path in #%datum manually or
+  ;; suffer a "#%datum not bound in the transformer environment" error.
+  #:with runtime-path-define
+  (datum->syntax #'path (syntax-e #'(define-runtime-path input (#%datum . path))) #'path)
+  (#%module-begin
+   (provide export)
+   runtime-path-define
+   (define tree (read-attribution-tree input))
+   (unless (validate-appraisal tree)
+     (error 'validate-appraisal "bad appraisal: ~a" tree))
+   (define export (make-hash))
+   (tally tree node-weight bump #:results export)
+   (unless (validate-attributions export)
+     (error 'validate-attributions "bad attributions: ~a" export))))
+
+(module reader syntax/module-reader abe/attribution)

--- a/dia/tree-parser.rkt
+++ b/dia/tree-parser.rkt
@@ -1,0 +1,160 @@
+#lang racket
+
+(provide read-attribution-tree
+         read-idea-attribution-tree
+         read-idea-antecedents-tree)
+
+#| TREE PARSING UTILITIES
+
+Textual tree formats described in attribution.rkt, antecedents.rkt next to this
+file.
+
+The exported functions receive a filepath, convert it to lines, and parse the
+corresponding kind of tree.
+
+|#
+
+(require racket/hash
+         qi)
+
+;; If this is not defined with function syntax, inner implementation functions
+;; unbound because they are eagerly evaluated.
+(define-flow (read-attribution-tree f)
+  (~> file->lines
+      (make-indent-based-tree (flow (regexp-replace* #px"[[:blank:]]" _ " ")))
+      (tree-map label->attribution leaf->attribution)))
+
+(define-flow (read-idea-attribution-tree f)
+  (~> file->lines
+      (make-indent-based-tree (flow (regexp-replace* #px"[[:blank:]]" _ " ")))
+      (tree-map label->attribution label->attribution)))
+
+(define-flow (read-idea-antecedents-tree f)
+  (~> file->lines
+      (make-indent-based-tree (flow (regexp-replace* #px"[[:blank:]]" _ " ")))
+      (tree-map values leaf->antecedents)
+      (leaves->hash car cdr)))
+
+#| Implementation notes
+
+Done by recursive process. An iterative solution is desired if it is performant
+and equally readable. Otherwise, this is the best way to understand the process
+as it stands:
+
+When the indentation doesn't change from line to line, the current line is a
+child of the current tree. Thus we cons it on to the tree built from the rest of
+the lines.
+
+When the indent increases, we are starting a new subtree. We bundle the
+remaining lines at this new indentation (make-groups-at), and make trees out of
+each bundle. These subtrees are then collected into a final tree.
+
+Further improvement: consider using a Markdown parser (require markdown) and
+processing the resultant structure?
+
+|#
+
+(define (make-indent-based-tree lines [on-line values])
+  (define by-indent
+    (for/list ([line lines])
+      (match-define (regexp #px"^(\\s*)" (list _ (app string-length indent))) line)
+      (cons indent (on-line line))))
+  (match by-indent
+    ['() '()]
+    [(cons (cons ind _) _)
+     (let make-tree ([indents by-indent]
+                     [prev-indent ind])
+       (match indents
+         ['() '()]
+         [(cons (cons ind line) indents)
+          (cond
+            [(= ind prev-indent)
+             (cons line (make-tree indents prev-indent))]
+            [(> ind prev-indent)
+             (map (flow (make-tree ind))
+                  (make-groups-at ind (cons (cons ind line) indents)))]
+            ;; all smaller have already been handled, so this would be a bug
+            ;; or bad input: say, the first line is indented and the next is not
+            [(< ind prev-indent)
+             (error 'make-tree "smaller indent: ~a < ~a in ~a" ind prev-indent indents)])]))]))
+
+#| Example:
+
+(make-groups-at 1 '((1 . a) (1 . b) (2 . c) (2 . d) (1 . e) (2 . f) (3 . g)))
+=>
+'(((1 . a))
+  ((1 . b) (2 . c) (2 . d))
+  ((1 . e) (2 . f) (3 . g)))
+
+|#
+(define (make-groups-at n xs)
+  (let loop ([acc null]
+             [xs xs])
+    (match xs
+      ['() (reverse acc)]
+      [(cons x xs)
+       (define-values (group rest)
+         (split-at xs (or (index-where xs (flow (~> car (= n))))
+                          (length xs))))
+       (loop (cons (cons x group) acc)
+             rest)])))
+
+#| Parsing leafs and labels.
+
+See adjacent module languages attribution.rkt, antecedents.rkt for more details
+on format.
+
+|#
+
+(define (leaf->attribution x)
+  (match x
+    [(regexp #px"^\\s*\\* ([^ ]+)(?:\\s+and\\s+([^ ]+))?.*\\[([[:digit:].]+)%\\]"
+             (list _ name1 name2 (app string->number attribution)))
+     (cons (if name2 (list name1 name2) name1)
+           attribution)]))
+
+(define (label->attribution x)
+  (match x
+    [(regexp #px"^\\s*\\* (.*) \\[([[:digit:].]+)%\\]"
+             (list _ thing (app string->number attribution)))
+     (cons thing attribution)]))
+
+(define (leaf->antecedents x)
+  (match x
+    [(regexp #px"^\\s*\\* (.*) \\[(.*)\\]" (list _ idea antecedents))
+     (cons idea (string-split antecedents ", "))]))
+
+(define (leaves->hash t k v)
+  (tree-fold t (hash) (flow (~> 2> sep hash-union)) (flow (~> (-< k v) hash))))
+
+#| Trees
+
+t := null | (cons label (listof t)) | (list leaf)
+leaf := any
+label := any
+
+These procedures implement relatively standard map and fold operations over
+trees of this kind.
+
+Map preserves structure but changes data: the label and leaf functions convert
+labels and leafs to new representations.
+
+Fold changes structure: z replaces the empty tree value null; leaf replaces the
+list contructor for leaves; label replaces the cons constructor for trees.
+
+|#
+
+(define (tree-map t label leaf)
+  (match t
+    ['() '()]
+    [(list x) (list (leaf x))]
+    [(cons x children)
+     (cons (label x)
+           (map (flow (tree-map label leaf)) children))]))
+
+(define (tree-fold t z label leaf)
+  (match t
+    ['() z]
+    [(list x) (leaf x)]
+    [(cons x children)
+     (label x (map (flow (tree-fold z label leaf)) children))]))

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,47 @@
+.POSIX:
+SHELL = /bin/sh
+
+# TEMPLATE MAKEFILE
+#
+# The attribution target deanonymizes as necessary, and then runs the
+# attribution script, dumping its results to a file. See the adjacent
+# synthesis.rkt script for how that works.
+#
+# The deanonymize target runs the deanonymization script (details on its
+# function in the source). You shouldn't need to run this manually very often
+# unless you want to deanonymize separately from attribution. See the adjacent
+# deanonymize.rkt for details.
+#
+# This Makefile assumes a project structure containing appraisal and attribution
+# files in certain places.
+
+DEANONYMIZED_OUT = evaluation/appraisal/deanonymized/capital.md \
+                   evaluation/appraisal/deanonymized/capital.md.sed \
+                   evaluation/appraisal/deanonymized/labor.md \
+                   evaluation/appraisal/deanonymized/labor.md.sed \
+
+DEANONYMIZED_IN = input/capital.md \
+                  input/capital-anonymized.md \
+                  input/labor.md \
+                  input/labor-anonymized.md \
+                  evaluation/appraisal/capital.md \
+                  evaluation/appraisal/labor.md \
+                  evaluation/appraisal/deanonymized/deanonymize.rkt
+
+.PHONY: deanonymize
+deanonymize: $(DEANONYMIZED_OUT)
+$(DEANONYMIZED_OUT): $(DEANONYMIZED_IN)
+	evaluation/appraisal/deanonymized/deanonymize.rkt --execute
+
+ATTRIBUTION_IN = $(DEANONYMIZED_OUT) \
+                 evaluation/appraisal/ideas.md \
+                 evaluation/antecedents/ideas.md \
+                 evaluation/attribution/capital.rkt \
+                 evaluation/attribution/ideas.rkt \
+                 evaluation/attribution/labor.rkt \
+                 evaluation/attribution/synthesis.rkt
+
+.PHONY: attribute
+attribute: evaluation/attribution/attribution.rktd
+evaluation/attribution/attribution.rktd: $(ATTRIBUTION_IN)
+	racket evaluation/attribution/synthesis.rkt > $@

--- a/tools/deanonymize.rkt
+++ b/tools/deanonymize.rkt
@@ -1,0 +1,95 @@
+#! /usr/bin/env racket
+#lang rash
+
+#| Overview
+
+Assumes a very specific project structure. See adjance Makefile example for
+details on "input" files and "output" files. Also assumes its placement in the
+project (next to the output files).
+
+*nix specifix: you'll need implementations of POSIX paste(1), column(1), and
+POSIX sed(1). The column(1) implementation should support `-t` and `-s`.
+
+1. Build lookup tables from the anonymized and named files. Uses paste(1) to
+   pair up lines and column(1) to separate them for post-processing.
+2. Generate sed(1) code from the lookup tables. N.B. This implies that
+   anonymized lines must be distinct, since they are effectively "keys."
+3. If given --execute, run the sed(1) code on the input files to generate
+   deanonymized output files.
+
+If you commit the sed(1) code, too, you ensure that Racket is not needed to
+regenerate the deanonymized files. In practice you would want Racket to generate
+the sed(1) code anyway.
+
+Rash tips: lines that don't start with parens are rash commands. Almost sh-like,
+but different. If you don't do anything too complicated, it'll probably work the
+way you think… but redirection operators are not normal! Inside parens, use {}
+to escape to Rash, or #{} to escape to Rash and capture the output, like $()
+in a shell. Use () to escape back to Racket, although variables can be accessed
+by $racket-variable or $ENVIRONMENT_VARIABLE.
+
+|#
+
+(require racket
+         racket/runtime-path
+         qi)
+
+(define-runtime-path here ".")
+(define evaluation (build-path here 'up 'up))
+(define inputs (build-path evaluation 'up "input"))
+(define appraisals (build-path evaluation "appraisal"))
+(define-flow input (build-path inputs __))
+(define-flow appraisal (build-path appraisals __))
+(define-flow output (build-path here __))
+(define-flow sed (~> (string-append ".sed") (build-path here __)))
+
+(define anon->actual
+  (hash "capital-anonymized.md" "capital.md"
+        "labor-anonymized.md" "labor.md"))
+
+(define (make-lookup anon actual)
+  (define anon-actual-table
+    #{paste $anon $actual | column -ts'* |> port->lines})
+  (for/hash ([line anon-actual-table])
+    (~> (line) (string-split "\t") (sep string-trim))))
+
+(define (lookup->sed lookup)
+  ;; sed uses BREs by default (man re_format). With a pattern separator of /,
+  ;; the only interesting metacharacters are /, \, ^ at the beginning of the
+  ;; pattern, and $ at the end of the pattern. The careful reader will note
+  ;; that, in the BRE \(^foo\), ^ is also a metacharacter; because we already
+  ;; escape the \( and \) metacharacters, there is no need to adjust this ^.
+  ;; More generally, escaping all \s escapes most of the unenhanced BRE
+  ;; metacharacters.
+  (define-flow sed-escape
+    ;; double-escaped replacements to quote the backslashes, not the following
+    ;; replacement characters.
+    (regexp-replaces '([#rx"[/\\]" "\\\\&"]
+                       [#rx"^\\^" "\\\\^"]
+                       [#rx"\\$$" "\\\\$"])))
+  (string-join
+    (for/list ([(anon actual) lookup])
+      (format "s/~a/~a/" (sed-escape anon) (sed-escape actual)))
+    "\n"))
+
+(define execute? (make-parameter #f))
+(command-line
+  #:usage-help
+  "Generate deanonymization scripts."
+  "When enabled, execute deanonymization scripts."
+  #:once-each
+  [("--execute") "execute deanonmyization" (execute? #t)]
+  #:args ()
+  (void))
+
+(for ([(anon actual) anon->actual])
+  (define lookup (make-lookup (input anon) (input actual)))
+  {
+    echo (lookup->sed lookup) &>! (sed actual)
+  })
+
+(when (execute?)
+  {
+    (for ([actual (in-hash-values anon->actual)])
+      { sed -f (sed actual) (appraisal actual) &>! (output actual) })
+  })

--- a/tools/synthesis.rkt
+++ b/tools/synthesis.rkt
@@ -1,0 +1,42 @@
+#lang racket
+
+#| TEMPLATE ATTRIBUTION SCRIPT
+
+This script performs attribution based on the subsidiary attributions in
+capital.rkt, labor.rkt, and ideas.rkt. It reconciles the various attributions,
+validates the result, and dumps it to stdout.
+
+See the example Makefile for usage instructions.
+
+Place this script with other attribution files, like the subsidiary
+attribution scripts and, possibly, outputs.
+
+|#
+
+(require abe/dia
+         qi
+         "capital.rkt"
+         "labor.rkt"
+         "ideas.rkt")
+
+(define attributions (make-hash))
+
+(define N 3)
+
+(reconcile-appraisals N
+                      labor-attributions
+                      capital-attributions
+                      antecedents-attributions
+                      attributions)
+
+(unless (validate-attributions attributions)
+  (error 'validate-attributions "bad attributions: ~a" attributions))
+
+(define-flow round-attribution
+  (~>> (~r #:precision '(= 2)) string->number))
+
+(~> (attributions)
+    (hash-map/copy (flow (== _ round-attribution)))
+    hash->list
+    (sort > #:key cdr)
+    pretty-print)


### PR DESCRIPTION
With these changes, it is possible to adjust the Qi DIA to _remove_ some module language and helper scripts. The stuff in `tools` would stay in each DIA repo to evolve separately as necessary, while the stuff in `dia` could stay here and benefit all users (while also nudging us toward standard formats).