### PR TITLE
A CLI script to convert an RKTD file to CSV

### DIFF
--- a/tools/rktd2csv.rkt
+++ b/tools/rktd2csv.rkt
@@ -13,7 +13,9 @@
       ;; a list of lists
       (map (☯ (~> (-< (~> car ->string) cdr)
                   list))
-           (eval (read port) (make-base-namespace))))))
+           ;; the value is read as `(quote ...)` as we use `pretty-print`,
+           ;; so extract the quoted list here via `cadr`
+           (cadr (read port))))))
 
 (define (write-csv data [headers #f])
   (let ([data (if headers

--- a/tools/rktd2csv.rkt
+++ b/tools/rktd2csv.rkt
@@ -1,0 +1,27 @@
+#!/usr/bin/env racket
+#lang cli
+
+(require csv-writing
+         qi
+         relation)
+
+(define (read-rktd filename)
+  (call-with-input-file filename
+    (λ (port)
+      ;; the input is a list of conses
+      ;; but we need a "table" which is
+      ;; a list of lists
+      (map (☯ (~> (-< (~> car ->string) cdr)
+                  list))
+           (eval (read port) (make-base-namespace))))))
+
+(define (write-csv data [headers #f])
+  (let ([data (if headers
+                  (cons headers data)
+                  data)])
+    (display-table data)))
+
+(program (main [rktd-filename "The RKTD file (e.g. an attributions file that is the output of DIA)."])
+  (write-csv (read-rktd rktd-filename)))
+
+(run main)


### PR DESCRIPTION
DIA currently produces an RKTD file (i.e. data formatted as Racket/Lisp nested list). Old Abe expects the attributions file to be a CSV, so this is a script to convert RKTD to CSV.

We could probably just generate CSV from DIA going forward, but for now, we need to convert both Symex and Qi attributions to CSV.

Output for Qi:
```
Sid,34.68
Racket,11.13
(Michael Sid),9.95
Ben,6.38
Noah,4.23
typed-stack,3.23
Stephen,3.01
adjutor,2.42
mischief,2.42
Jay,2.02
Michael,1.78
rackunit,1.38
(Ben Sid),1.04
Cassie,0.95
Sam,0.87
Kasivajhula 2014-,0.83
Sergiu,0.78
greg-racket-makefile,0.69
Laurent,0.62
Nia,0.59
metapict,0.58
cover,0.58
Haskell,0.56
Scheme,0.56
Bogdan,0.52
racket-collections,0.46
cover-coveralls,0.46
relation,0.46
(Jesse William),0.43
APL,0.43
Anonymous,0.42
Threading macro,0.42
pipeR,0.42
Clojure,0.39
Rash,0.35
Lisp,0.35
Symex,0.27
Debug,0.23
Soegaard,0.23
1e1001,0.22
Scratch (MIT),0.22
VHDL,0.21
Verilog,0.21
Hsiao-Peng et. al. 1999,0.21
jo-sm,0.21
Unix pipelines,0.21
Scala,0.21
Erlang,0.21
Ballantyne et al 2020,0.17
(Sorawee Jack),0.16
Sarna,0.15
ML,0.14
Hughes 2000,0.13
Vim,0.13
Python,0.04
Ruby,0.04
```

Symex:
```
sid,42.181459
emacs,7.849714
simon,6.253159
evil,6.065714
paredit,4.975714
jeff,4.968
hydra,2.49
tommy,2.425281
markgdawson,2.1114
riscy,1.863
apl,1.68
jake,1.6422
doyougnu,1.449
lispy,1.433714
ariana,1.242
pepperblue,1.242
vim,1.235714
anonimitoraf,1.1592
melpazoid,1.15
tsc,1.127
dcostaras,1.02465
gremlin,0.985714
tarsius,0.621
tree-sitter,0.568714
anonymous,0.50715
racket mode,0.204
cider,0.204
arc mode,0.192
scheme mode,0.192
evil-surround,0.161
evil-cleverparens,0.161
devcarbon,0.15525
basilconto,0.15525
slime,0.102
sly,0.102
parinfer,0.06
drracket,0.06
```
