### PR TITLE
Module langs for source files

### DIFF
--- a/dia/antecedents.rkt
+++ b/dia/antecedents.rkt
@@ -37,8 +37,8 @@ leaves have antecedents. But this has only been tested on antecedents trees.
   (#%module-begin
    (provide export)
    ;; unless path-strings quoted, #%datum unbound error (not sure why not automatically introduced)
-   (define tree (read-idea-attribution-tree 'ideas-p))
-   (define antes (read-idea-antecedents-tree 'antecedents-p))
+   (define tree (call-with-input-file 'ideas-p read-idea-attribution-tree))
+   (define antes (call-with-input-file 'antecedents-p read-idea-antecedents-tree))
    (unless (validate-appraisal tree)
      (error 'validate-appraisal "bad appraisal: ~a" tree))
    (define export (make-hash))

--- a/dia/antecedents2.rkt
+++ b/dia/antecedents2.rkt
@@ -1,0 +1,63 @@
+#lang racket
+
+(provide (rename-out [mb #%module-begin]) #%datum #%top #%top-interaction #%app)
+
+#| (Unstable) Module language for antecedents
+
+Format:
+  #lang abe/antecedents2 exported-antecedents-id [ideas-module imported-ideas-id]
+
+  - antecedents tree [antecedents]
+
+Meaning:
+
+- The body is an "antecedents" tree of roughly the same shape where the leaves
+have comma-separated antecedents in place of percentages.
+- Attribute antecedents by combining them with imported-ideas-id from
+ideas-module, which records the idea appraisals (see #lang abe/ideas2).
+- Export (provide) the exported-antecedents-id bound to the final attributions.
+
+|#
+
+(require syntax/parse/define
+         abe/dia)
+
+(define-syntax-parse-rule
+  (mb export:id {~datum <=} [ideas-mod:expr imported-ideas:id] {~datum <=} tree-data:expr)
+  (#%module-begin
+   (provide export)
+   (require (only-in ideas-mod imported-ideas))
+   (define antes 'tree-data)
+   (define export (make-hash))
+   (attribute-antecedents imported-ideas antes export)
+   (unless (validate-attributions export)
+     (error 'validate-attributions "bad attributions: ~a" export))))
+
+(module reader syntax/module-reader abe/antecedents2
+  #:whole-body-readers? #t
+  #:read reader
+  #:read-syntax syntax-reader
+
+  (require racket/match
+           syntax/strip-context
+           abe/tree-parser)
+
+  (define (syntax-reader src in)
+    (port-count-lines! in)
+    (define name (read-syntax src in))
+    (unless (symbol? (syntax-e name))
+      (raise (exn:fail:read
+              (format "expected identifier\n  read: ~s" name)
+              (current-continuation-marks)
+              (list (srcloc src (syntax-line name) (syntax-column name) (syntax-position name) (syntax-span name))))))
+    (define import (read-syntax src in))
+    (match (syntax->datum import)
+      [(list (not (? keyword?)) (? symbol?)) (void)]
+      [_ (raise (exn:fail:read
+                    (format "expected [module identifier]\n  read: ~s" import)
+                    (current-continuation-marks)
+                    (list (srcloc src (syntax-line name) (syntax-column name) (syntax-position name) (syntax-span name)))))])
+    (define tree (read-idea-antecedents-tree in))
+    (strip-context #`(#,name <= #,import <= #,tree)))
+  (define (reader in)
+    (syntax->datum (syntax-reader #f in))))

--- a/dia/attribution.rkt
+++ b/dia/attribution.rkt
@@ -40,7 +40,7 @@ larger than 2 are not yet supported.
   (#%module-begin
    (provide export)
    ;; unless path-strings quoted, #%datum unbound error (not sure why not automatically introduced)
-   (define tree (read-attribution-tree 'input))
+   (define tree (call-with-input-file 'input read-attribution-tree))
    (unless (validate-appraisal tree)
      (error 'validate-appraisal "bad appraisal: ~a" tree))
    (define export (make-hash))

--- a/dia/attribution2.rkt
+++ b/dia/attribution2.rkt
@@ -7,7 +7,7 @@
 Format:
   #lang abe/attribution2 exported-attributions-id
 
-  - Appraisal tree [N%]
+  - [contributors] Appraisal tree [N%]
   ...
 
 Meaning:
@@ -19,14 +19,9 @@ with bracketed percentags [N%] at the end of the line.
 - Validate attributions.
 - Export (provide) the exported-attributions-id bound to the attributions.
 
-To identify attributions, the first sequence of non-space characters after a
-bullet is used. For capital, this means that descriptive bullets without a
-project name should be given a faux project name.
-
-Additionally, a sequence of non-space characters followed by the text " and "
-and another sequence of non-space characters is considered an attributive "pair"
-and is attributed as a single unit, to account for teamwork. Groups of sizes
-larger than 2 are not yet supported.
+To identify attributions, contributors are listed, comma-separated, in
+[square-brackets] at the beginning of a bullet. This holds for labor, too, to
+name the project but permit additional description.
 
 |#
 
@@ -61,7 +56,7 @@ larger than 2 are not yet supported.
               (format "expected identifier\n  read: ~s" name)
               (current-continuation-marks)
               (list (srcloc src (syntax-line name) (syntax-column name) (syntax-position name) (syntax-span name))))))
-    (define tree (read-attribution-tree in))
+    (define tree (read-attribution-tree2 in))
     (strip-context #`(#,name <= #,tree)))
   (define (reader in)
     (syntax->datum (syntax-reader #f in))))

--- a/dia/attribution2.rkt
+++ b/dia/attribution2.rkt
@@ -1,0 +1,67 @@
+#lang racket
+
+(provide (rename-out [mb #%module-begin]) #%datum #%top #%top-interaction #%app)
+
+#| (Unstable) Module language for attributions
+
+Format:
+  #lang abe/attribution2 exported-attributions-id
+
+  - Appraisal tree [N%]
+  ...
+
+Meaning:
+
+- The body is an "appraisal" tree. Roughly, markdown bulleted list in tree form,
+with bracketed percentags [N%] at the end of the line.
+- Validate appraisals.
+- Tally attributions.
+- Validate attributions.
+- Export (provide) the exported-attributions-id bound to the attributions.
+
+To identify attributions, the first sequence of non-space characters after a
+bullet is used. For capital, this means that descriptive bullets without a
+project name should be given a faux project name.
+
+Additionally, a sequence of non-space characters followed by the text " and "
+and another sequence of non-space characters is considered an attributive "pair"
+and is attributed as a single unit, to account for teamwork. Groups of sizes
+larger than 2 are not yet supported.
+
+|#
+
+(require syntax/parse/define
+         abe/dia)
+
+(define-syntax-parse-rule
+  (mb export:id {~datum <=} tree-data:expr)
+  (#%module-begin
+   (provide export)
+   (define tree 'tree-data)
+   (unless (validate-appraisal tree)
+     (error 'validate-appraisal "bad appraisal: ~a" tree))
+   (define export (make-hash))
+   (tally tree node-weight bump #:results export)
+   (unless (validate-attributions export)
+     (error 'validate-attributions "bad attributions: ~a" export))))
+
+(module reader syntax/module-reader abe/attribution2
+  #:whole-body-readers? #t
+  #:read reader
+  #:read-syntax syntax-reader
+
+  (require syntax/strip-context
+           abe/tree-parser)
+
+  (define (syntax-reader src in)
+    (port-count-lines! in)
+    (define name (read-syntax src in))
+    (unless (symbol? (syntax-e name))
+      (raise (exn:fail:read
+              (format "expected identifier\n  read: ~s" name)
+              (current-continuation-marks)
+              (list (srcloc src (syntax-line name) (syntax-column name) (syntax-position name) (syntax-span name))))))
+    (define tree (read-attribution-tree in))
+    (strip-context #`(#,name <= #,tree)))
+  (define (reader in)
+    (syntax->datum (syntax-reader #f in))))

--- a/dia/ideas2.rkt
+++ b/dia/ideas2.rkt
@@ -1,0 +1,57 @@
+#lang racket
+
+(provide (rename-out [mb #%module-begin]) #%datum #%top #%top-interaction #%app)
+
+#| (Unstable) Module language for ideas
+
+Format:
+  #lang abe/ideas2 exported-ideas-id
+
+  - Ideas appraisal tree [N%]
+
+Meaning:
+
+- The body is an "appraisal" tree. Roughly, markdown bulleted list in tree
+form, with bracketed percentags [N%] at the end of the line.
+- Validate appraisals.
+- Tally idea attributions.
+- Validate attributions.
+- Export (provide) the exported-ideas-id bound to the attributions.
+
+|#
+
+(require syntax/parse/define
+         abe/dia)
+
+(define-syntax-parse-rule
+  (mb export:id {~datum <=} tree-data:expr)
+  (#%module-begin
+   (provide export)
+   (define tree 'tree-data)
+   (unless (validate-appraisal tree)
+     (error 'validate-appraisal "bad appraisal: ~a" tree))
+   (define export (make-hash))
+   (tally tree node-weight bump #:results export)
+   (unless (validate-attributions export)
+     (error 'validate-attributions "bad attributions: ~a" export))))
+
+(module reader syntax/module-reader abe/ideas2
+  #:whole-body-readers? #t
+  #:read reader
+  #:read-syntax syntax-reader
+
+  (require syntax/strip-context
+           abe/tree-parser)
+
+  (define (syntax-reader src in)
+    (port-count-lines! in)
+    (define name (read-syntax src in))
+    (unless (symbol? (syntax-e name))
+      (raise (exn:fail:read
+              (format "expected identifier\n  read: ~s" name)
+              (current-continuation-marks)
+              (list (srcloc src (syntax-line name) (syntax-column name) (syntax-position name) (syntax-span name))))))
+    (define tree (read-idea-attribution-tree in))
+    (strip-context #`(#,name <= #,tree)))
+  (define (reader in)
+    (syntax->datum (syntax-reader #f in))))

--- a/dia/tree-parser.rkt
+++ b/dia/tree-parser.rkt
@@ -21,16 +21,19 @@ corresponding kind of tree.
 ;; unbound because they are eagerly evaluated.
 (define-flow (read-attribution-tree ip)
   (~> port->lines
+      (filter non-empty-string? _)
       (make-indent-based-tree (flow (regexp-replace* #px"[[:blank:]]" _ " ")))
       (tree-map label->attribution leaf->attribution)))
 
 (define-flow (read-idea-attribution-tree ip)
   (~> port->lines
+      (filter non-empty-string? _)
       (make-indent-based-tree (flow (regexp-replace* #px"[[:blank:]]" _ " ")))
       (tree-map label->attribution label->attribution)))
 
 (define-flow (read-idea-antecedents-tree ip)
   (~> port->lines
+      (filter non-empty-string? _)
       (make-indent-based-tree (flow (regexp-replace* #px"[[:blank:]]" _ " ")))
       (tree-map values leaf->antecedents)
       (leaves->hash car cdr)))

--- a/dia/tree-parser.rkt
+++ b/dia/tree-parser.rkt
@@ -19,18 +19,18 @@ corresponding kind of tree.
 
 ;; If this is not defined with function syntax, inner implementation functions
 ;; unbound because they are eagerly evaluated.
-(define-flow (read-attribution-tree f)
-  (~> file->lines
+(define-flow (read-attribution-tree ip)
+  (~> port->lines
       (make-indent-based-tree (flow (regexp-replace* #px"[[:blank:]]" _ " ")))
       (tree-map label->attribution leaf->attribution)))
 
-(define-flow (read-idea-attribution-tree f)
-  (~> file->lines
+(define-flow (read-idea-attribution-tree ip)
+  (~> port->lines
       (make-indent-based-tree (flow (regexp-replace* #px"[[:blank:]]" _ " ")))
       (tree-map label->attribution label->attribution)))
 
-(define-flow (read-idea-antecedents-tree f)
-  (~> file->lines
+(define-flow (read-idea-antecedents-tree ip)
+  (~> port->lines
       (make-indent-based-tree (flow (regexp-replace* #px"[[:blank:]]" _ " ")))
       (tree-map values leaf->antecedents)
       (leaves->hash car cdr)))

--- a/tools/deanonymize.rkt
+++ b/tools/deanonymize.rkt
@@ -3,11 +3,11 @@
 
 #| Overview
 
-Assumes a very specific project structure. See adjance Makefile example for
+Assumes a very specific project structure. See adjacent Makefile example for
 details on "input" files and "output" files. Also assumes its placement in the
 project (next to the output files).
 
-*nix specifix: you'll need implementations of POSIX paste(1), column(1), and
+*nix specifics: you'll need implementations of POSIX paste(1), column(1), and
 POSIX sed(1). The column(1) implementation should support `-t` and `-s`.
 
 1. Build lookup tables from the anonymized and named files. Uses paste(1) to


### PR DESCRIPTION
Please provide commentary, feedback, jokes, suggestions, etc.

To prove that this works, there's a minimal patch to drym-org/dia-qi that causes
```
racket evaluation/attribution/synthesis.rkt > evaluation/attribution/attribution.rktd
```
(as in `make attribute` but without depending on deanonymization results—the reason for this is clarified later) to succeed without changing the output. Copy it to a file and `git apply <file>` in a clone of drym-org/dia-qi to try it out (after checking out this branch and `raco setup -p abe`). 

1. Create a set of unstable module langs (suffixed `2`) that read trees as the main body of the module (some important modifiers are expected directly after the lang line, though arbitrary whitespace can separate them). This is a first draft to solve #4.

    Note in particular that the `#lang` modifications to deanonymized files are overwritten by `make` when the deanonymization script runs, so I expect this PR to start tackling #6 among several other issues to wrap everything together.

1. Standardize contributor syntax as in #5.

    N.B. In the proof patch, I only changed the head of input bullets; I didn't fix the grammar of the resulting bullets to match the proposal in #6. I probably will eventually.

<details>
<summary>Patch for drym-org/dia-qi</summary>

```diff
diff --git i/evaluation/antecedents/ideas.md w/evaluation/antecedents/ideas.md
index eea0e5b..2410648 100644
--- i/evaluation/antecedents/ideas.md
+++ w/evaluation/antecedents/ideas.md
@@ -1,3 +1,5 @@
+#lang abe/antecedents2 antecedents-attributions ["../appraisal/ideas.md" ideas]
+
 * Qi []
 	* DSL []
 		* syntax []
diff --git i/evaluation/appraisal/deanonymized/capital.md w/evaluation/appraisal/deanonymized/capital.md
index cc49897..f4369e3 100644
--- i/evaluation/appraisal/deanonymized/capital.md
+++ w/evaluation/appraisal/deanonymized/capital.md
@@ -1,15 +1,17 @@
+#lang abe/attribution2 capital-attributions
+
 * Qi [100%]
    * Core/Platform [45%]
-       * Racket [100%]
+       * [Racket] [100%]
    * Initial Implementation [35%]
-       * typed-stack [40%]
-       * mischief [30%]
-       * adjutor [30%]
+       * [typed-stack] [40%]
+       * [mischief] [30%]
+       * [adjutor] [30%]
    * Dev Tools [20%]
-       * rackunit [30%]
-       * cover [12.5%]
-       * cover-coveralls [10%]
-       * relation [10%]
-       * racket-collections [10%]
-       * metapict [12.5%]
-       * greg-racket-makefile : Greg's Makefile for Racket projects [15%]
+       * [rackunit] [30%]
+       * [cover] [12.5%]
+       * [cover-coveralls] [10%]
+       * [relation] [10%]
+       * [racket-collections] [10%]
+       * [metapict] [12.5%]
+       * [greg-racket-makefile] Greg's Makefile for Racket projects [15%]
diff --git i/evaluation/appraisal/deanonymized/capital.md.sed w/evaluation/appraisal/deanonymized/capital.md.sed
index d88eedf..892970b 100644
--- i/evaluation/appraisal/deanonymized/capital.md.sed
+++ w/evaluation/appraisal/deanonymized/capital.md.sed
@@ -1,11 +1,11 @@
-s/A tool to draw graphics used in documentation/metapict/
-s/A macro from a utility library that was used to define aliases for syntactic forms in the initial implementation and is no longer used/mischief/
-s/A library providing a stack data structure that was used in the initial implementation of the `block` form and is no longer used/typed-stack/
-s/Generic operations on collections from a utility library that are used to simplify working with collections in build scripts/racket-collections/
-s/The platform on which Qi is built/Racket/
-s/A tool to integrate coverage reporting with the Coveralls service in CI/cover-coveralls/
-s/A test coverage reporting tool/cover/
-s/A Makefile that was used as the starting point to automate common project development actions, serving as a template for future expansion/greg-racket-makefile : Greg's Makefile for Racket projects/
-s/Generic operators from a utility library that were used to simplify documentation and build scripts in the initial implementation, and which are currently used only in build scripts/relation/
-s/A macro from a utility library that was used to convert from values to lists in the initial implementation and is no longer used/adjutor/
-s/A unit testing framework/rackunit/
+s/A tool to draw graphics used in documentation/[metapict]/
+s/A macro from a utility library that was used to define aliases for syntactic forms in the initial implementation and is no longer used/[mischief]/
+s/A library providing a stack data structure that was used in the initial implementation of the `block` form and is no longer used/[typed-stack]/
+s/Generic operations on collections from a utility library that are used to simplify working with collections in build scripts/[racket-collections]/
+s/The platform on which Qi is built/[Racket]/
+s/A tool to integrate coverage reporting with the Coveralls service in CI/[cover-coveralls]/
+s/A test coverage reporting tool/[cover]/
+s/A Makefile that was used as the starting point to automate common project development actions, serving as a template for future expansion/[greg-racket-makefile] Greg's Makefile for Racket projects/
+s/Generic operators from a utility library that were used to simplify documentation and build scripts in the initial implementation, and which are currently used only in build scripts/[relation]/
+s/A macro from a utility library that was used to convert from values to lists in the initial implementation and is no longer used/[adjutor]/
+s/A unit testing framework/[rackunit]/
diff --git i/evaluation/appraisal/deanonymized/labor.md w/evaluation/appraisal/deanonymized/labor.md
index 2409252..9cd8e6c 100644
--- i/evaluation/appraisal/deanonymized/labor.md
+++ w/evaluation/appraisal/deanonymized/labor.md
@@ -1,106 +1,108 @@
+#lang abe/attribution2 labor-attributions
+
 * Qi [100%]
 	* Initial work / foundation [25%]
-		* Sid designed the language [50%]
-		* Sid wrote the initial implementation [50%]
+		* [Sid] designed the language [50%]
+		* [Sid] wrote the initial implementation [50%]
 	* Promotion / getting the word out / community [25%]
-		* Sid was invited to give a talk at RacketCon [6.5%]
-		* Jay gave feedback on Sid's talk [6.5%]
-		* Sid gave a talk at RacketCon [15.5%]
-		* Jay led the QA Q&A was held after the talkA for the talk [4.5%]
-		* Ben used and advocated for Qi [5.5%]
-		* Cassie used and advocated for Qi [5.5%]
-		* Stephen used and advocated for Qi [5.5%]
-		* Ben solved Advent of Code using Qi [5.5%]
-		* Stephen suggested the idea of a Qi-themed event [2.5%]
-		* Sid organized the Qi design challenge [4.5%]
-		* Michael and Sid started a weekly meetup for the project and maintained [10.5%]
-		* Noah wrote the first library extending Qi functionality [5.5%]
-		* Jesse and William suggested writing a tutorial [2.5%]
-		* Sid wrote an interactive tutorial using racket templates [9.5%]
-		* Ben wrote the first application leveraging Qi [5.5%]
-		* Sergiu drew a theoretical connection between Qi and Arrows in category theory.[4.5%]
+		* [Sid] was invited to give a talk at RacketCon [6.5%]
+		* [Jay] gave feedback on Sid's talk [6.5%]
+		* [Sid] gave a talk at RacketCon [15.5%]
+		* [Jay] led the QA Q&A was held after the talkA for the talk [4.5%]
+		* [Ben] used and advocated for Qi [5.5%]
+		* [Cassie] used and advocated for Qi [5.5%]
+		* [Stephen] used and advocated for Qi [5.5%]
+		* [Ben] solved Advent of Code using Qi [5.5%]
+		* [Stephen] suggested the idea of a Qi-themed event [2.5%]
+		* [Sid] organized the Qi design challenge [4.5%]
+		* [Michael, Sid] started a weekly meetup for the project and maintained [10.5%]
+		* [Noah] wrote the first library extending Qi functionality [5.5%]
+		* [Jesse, William] suggested writing a tutorial [2.5%]
+		* [Sid] wrote an interactive tutorial using racket templates [9.5%]
+		* [Ben] wrote the first application leveraging Qi [5.5%]
+		* [Sergiu] drew a theoretical connection between Qi and Arrows in category theory.[4.5%]
 	* Documentation [10%]
-		* Laurent added a quickscript for interactive evaluation in DrRacket to support the Qi tutorial [9%]
-		* Ben made improvements to a Vim plugin to better support the Qi tutorial [7%]
-		* Stephen reported a broken link in the documentation [3%]
-		* Anonymous suggested creating a wiki for Qi [6%]
-		* Sid created a wiki [12%]
-		* Sid wrote a Developer's Guide containing developer documentation [16%]
-		* Sid wrote docs for Qi [42%]
-		* Noah fixed some formatting and typos in the docs [5%]
+		* [Laurent] added a quickscript for interactive evaluation in DrRacket to support the Qi tutorial [9%]
+		* [Ben] made improvements to a Vim plugin to better support the Qi tutorial [7%]
+		* [Stephen] reported a broken link in the documentation [3%]
+		* [Anonymous] suggested creating a wiki for Qi [6%]
+		* [Sid] created a wiki [12%]
+		* [Sid] wrote a Developer's Guide containing developer documentation [16%]
+		* [Sid] wrote docs for Qi [42%]
+		* [Noah] fixed some formatting and typos in the docs [5%]
 	* Improving usability / ease of adoption: [7.5%]
 		* Distribution [40%]
-			* Stephen suggested distributing a Qi template using racket templates [20%]
-			* Stephen suggested decomposing the package into lib/test/doc packages for more flexible development and distribution [20%]
-			* Sid decomposed the package into lib/test/doc packages [50%]
-			* jo-sm reported an installation issue [10%]
+			* [Stephen] suggested distributing a Qi template using racket templates [20%]
+			* [Stephen] suggested decomposing the package into lib/test/doc packages for more flexible development and distribution [20%]
+			* [Sid] decomposed the package into lib/test/doc packages [50%]
+			* [jo-sm] reported an installation issue [10%]
 		* IDE support [18%]
-			* Stephen wrote a quickscript for entering unicode in DrRacket [30%]
-			* Sid added a flow-oriented debugger [70%]
-		* Stephen modified the package config so that Qi appears in the languages section of the docs [6%]
-		* Sam provided a recipe for hosting backup documentation in case the package index is unavailable [6%]
-		* Sid added the backup docs workflow following Sam's recipe [5%]
-		* Sid migrated the repo to an organization account [5%]
-		* Ben and Sid provided technical support to Qi users [20%]
+			* [Stephen] wrote a quickscript for entering unicode in DrRacket [30%]
+			* [Sid] added a flow-oriented debugger [70%]
+		* [Stephen] modified the package config so that Qi appears in the languages section of the docs [6%]
+		* [Sam] provided a recipe for hosting backup documentation in case the package index is unavailable [6%]
+		* [Sid] added the backup docs workflow following Sam's recipe [5%]
+		* [Sid] migrated the repo to an organization account [5%]
+		* [Ben, Sid] provided technical support to Qi users [20%]
 	* Implementation [25%]
-		* Michael and Sid refactored the core macro into separate expansion and compilation stages [27.5%]
+		* [Michael, Sid] refactored the core macro into separate expansion and compilation stages [27.5%]
 		* Macro extensibility [32.5%]
-			* Sid designed a simple macro extensibility based on prefix matching, to allow users to extend the syntax of the language in a rudimentary way [10%]
-			* Sam provided an implementation for the prefix matching macro extensibility scheme [10%]
-			* Michael suggested many options for proper macro extensibility [20%]
-			* Michael and Sid implemented "first class" macro extensibility (based on Michael et al's paper), allowing users to seamlessly extend the syntax of the language [60%]
+			* [Sid] designed a simple macro extensibility based on prefix matching, to allow users to extend the syntax of the language in a rudimentary way [10%]
+			* [Sam] provided an implementation for the prefix matching macro extensibility scheme [10%]
+			* [Michael] suggested many options for proper macro extensibility [20%]
+			* [Michael, Sid] implemented "first class" macro extensibility (based on Michael et al's paper), allowing users to seamlessly extend the syntax of the language [60%]
 		* Form improvements [32.5%]
 			* Switch form [10%]
-				* Jay suggested improvements to switch [20%]
-				* Sid implemented improvements to switch [60%]
-				* Sid fixed some bugs in switch [20%]
+				* [Jay] suggested improvements to switch [20%]
+				* [Sid] implemented improvements to switch [60%]
+				* [Sid] fixed some bugs in switch [20%]
 			* Clos form [14%]
-				* Ben provided a design example to motivate adding closures (the clos form) to Qi [45%]
-				* Soegaard suggested the name clos for this form [10%]
-				* Sid implemented the clos form [45%]
+				* [Ben] provided a design example to motivate adding closures (the clos form) to Qi [45%]
+				* [Soegaard] suggested the name clos for this form [10%]
+				* [Sid] implemented the clos form [45%]
 			* Threading form [11%]
-				* Ben reported a confusing error message in the threading form and suggested a way to handle it [20%]
-				* Sid implemented Ben's suggested error message fix [20%]
-				* Nia identified an elusive bug causing performance degradation in the threading form [30%]
-				* Michael identified a hygiene issue related to the same bug that could have caused other bugs in the future [30%]
+				* [Ben] reported a confusing error message in the threading form and suggested a way to handle it [20%]
+				* [Sid] implemented Ben's suggested error message fix [20%]
+				* [Nia] identified an elusive bug causing performance degradation in the threading form [30%]
+				* [Michael] identified a hygiene issue related to the same bug that could have caused other bugs in the future [30%]
 			* Feedback form design improvements [13%]
-				* 1e1001 provided an illustrative example to motivate design improvements to the `feedback` form of the language [30%]
-				* Sid improved the design of `feedback` [50%]
-				* Ben reviewed the PR improving the design of `feedback` [20%]
+				* [1e1001] provided an illustrative example to motivate design improvements to the `feedback` form of the language [30%]
+				* [Sid] improved the design of `feedback` [50%]
+				* [Ben] reviewed the PR improving the design of `feedback` [20%]
 			* Restricting fancy-app [11%]
-				* Nia suggested restricting fancy-app's scope in Qi to avoid tricky bugs in handling user input [45%]
-				* Sid restricted fancy-app to just the fine-grained application form [35%]
-				* Nia reviewed the fancy-app PR [20%]
+				* [Nia] suggested restricting fancy-app's scope in Qi to avoid tricky bugs in handling user input [45%]
+				* [Sid] restricted fancy-app to just the fine-grained application form [35%]
+				* [Nia] reviewed the fancy-app PR [20%]
 			* Optimizing fanout [9%]
-				* Ben pointed out that fanout does not accept arbitrary Racket expressions for N [15%]
-				* Ben suggested an optimized implementation for fanout [30%]
-				* Sid modified fanout to support arbitrary expressions for N and have an optimized implementation [40%]
-				* Ben reviewed the fanout PR [15%]
+				* [Ben] pointed out that fanout does not accept arbitrary Racket expressions for N [15%]
+				* [Ben] suggested an optimized implementation for fanout [30%]
+				* [Sid] modified fanout to support arbitrary expressions for N and have an optimized implementation [40%]
+				* [Ben] reviewed the fanout PR [15%]
 			* Partition [13%]
-				* Ben added partition, a generalized version of the sieve form [80%]
-				* Sid reviewed the partition PR [20%]
-			* Noah added the ability to support the _ template in the function position [10%]
-			* Noah added support for keyword arguments to add bindings in lambda forms of the language [9%]
+				* [Ben] added partition, a generalized version of the sieve form [80%]
+				* [Sid] reviewed the partition PR [20%]
+			* [Noah] added the ability to support the _ template in the function position [10%]
+			* [Noah] added support for keyword arguments to add bindings in lambda forms of the language [9%]
 		* Reducing tech debt [7.5%]
-			* Noah updated uses of deprecated macro form ~or to ~or* [38%]
-			* Noah removed the unused let/flow and let/switch macros [38%]
-			* Noah improved the organization of some tests [24%]
+			* [Noah] updated uses of deprecated macro form ~or to ~or* [38%]
+			* [Noah] removed the unused let/flow and let/switch macros [38%]
+			* [Noah] improved the organization of some tests [24%]
 	* Operational excellence [7.5%]
 		* Performance [60%]
-			* Ben optimized the partition implementation [10%]
-			* Sid added benchmarking scripts [15%]
-			* Michael did an audit of the performance benchmarks for accuracy [15%]
-			* Sid fixed the benchmarks according to the audit [5%]
-			* Ben reduced the number of dependencies [9%]
-			* Ben used the tools to identify and remove all heavy dependencies and dramatically reduce load-time latency [18%]
-			* Noah significantly improved the performance of any?, all?, and none? [18%]
-			* Sorawee and Jack suggested using indirect documentation links to reduce build times [5%]
-			* Soegaard suggested some improvements to reduce memory consumption in building docs [5%]
+			* [Ben] optimized the partition implementation [10%]
+			* [Sid] added benchmarking scripts [15%]
+			* [Michael] did an audit of the performance benchmarks for accuracy [15%]
+			* [Sid] fixed the benchmarks according to the audit [5%]
+			* [Ben] reduced the number of dependencies [9%]
+			* [Ben] used the tools to identify and remove all heavy dependencies and dramatically reduce load-time latency [18%]
+			* [Noah] significantly improved the performance of any?, all?, and none? [18%]
+			* [Sorawee, Jack] suggested using indirect documentation links to reduce build times [5%]
+			* [Soegaard] suggested some improvements to reduce memory consumption in building docs [5%]
 		* Dev Tools [40%]
-			* Sid set up CI for the project repository [22%]
-			* Sid added performance benchmarking to CI [16%]
-			* Bogdan wrote a dependency profiler tool to identify heavy dependencies [25%]
-			* Sarna suggested a way to measure load-time latency [7%]
-			* Sid wrote a script to measure load-time latency following that approach [12%]
-			* Ben reviewed the load-time latency PR [8%]
-			* Ben modified the benchmarks runner config to avoid reporting success when it failed [10%]
+			* [Sid] set up CI for the project repository [22%]
+			* [Sid] added performance benchmarking to CI [16%]
+			* [Bogdan] wrote a dependency profiler tool to identify heavy dependencies [25%]
+			* [Sarna] suggested a way to measure load-time latency [7%]
+			* [Sid] wrote a script to measure load-time latency following that approach [12%]
+			* [Ben] reviewed the load-time latency PR [8%]
+			* [Ben] modified the benchmarks runner config to avoid reporting success when it failed [10%]
diff --git i/evaluation/appraisal/deanonymized/labor.md.sed w/evaluation/appraisal/deanonymized/labor.md.sed
index 7444662..cae6cc3 100644
--- i/evaluation/appraisal/deanonymized/labor.md.sed
+++ w/evaluation/appraisal/deanonymized/labor.md.sed
@@ -1,85 +1,85 @@
-s/Performance benchmarking was added to CI/Sid added performance benchmarking to CI/
-s/The wiki was created/Sid created a wiki/
-s/The name clos was suggested for this form/Soegaard suggested the name clos for this form/
-s/The fanout PR was reviewed/Ben reviewed the fanout PR/
-s/A way to measure load-time latency was suggested/Sarna suggested a way to measure load-time latency/
-s/"First class" macro extensibility was implemented, allowing users to seamlessly extend the syntax of the language/Michael and Sid implemented "first class" macro extensibility (based on Michael et al's paper), allowing users to seamlessly extend the syntax of the language/
-s/The clos form was implemented/Sid implemented the clos form/
-s/An early adopter advocated for the project (2)/Cassie used and advocated for Qi/
-s/The language was designed/Sid designed the language/
-s/There was a suggestion to distribute a Qi template using racket templates/Stephen suggested distributing a Qi template using racket templates/
-s/The partition implementation was optimized/Ben optimized the partition implementation/
-s/The suggested error message fix was implemented/Sid implemented Ben's suggested error message fix/
-s/partition was added, which is a generalized version of the sieve form/Ben added partition, a generalized version of the sieve form/
-s/There was a suggestion to create a wiki for Qi/Anonymous suggested creating a wiki for Qi/
-s/There was a suggestion to decompose the package into lib\/test\/doc packages for more flexible development and distribution/Stephen suggested decomposing the package into lib\/test\/doc packages for more flexible development and distribution/
-s/A weekly meetup for the project was started/Michael and Sid started a weekly meetup for the project/
-s/It was pointed out that fanout does not accept arbitrary Racket expressions for N/Ben pointed out that fanout does not accept arbitrary Racket expressions for N/
-s/Advent of Code was solved using Qi/Ben solved Advent of Code using Qi/
-s/The initial author received expert feedback on drafts of the talk/Jay gave feedback on Sid's talk/
-s/A quickscript for interactive evaluation in DrRacket was added to support the Qi tutorial/Laurent added a quickscript for interactive evaluation in DrRacket to support the Qi tutorial/
-s/A broken link in the documentation was reported/Stephen reported a broken link in the documentation/
-s/The package config was modified so that Qi appears in the languages section of the docs/Stephen modified the package config so that Qi appears in the languages section of the docs/
-s/The repo was migrated to an organization account/Sid migrated the repo to an organization account/
-s/An installation issue was reported/jo-sm reported an installation issue/
-s/The initial author was invited to give a talk at RacketCon/Sid was invited to give a talk at RacketCon/
-s/The unused let\/flow and let\/switch macros were removed/Noah removed the unused let\/flow and let\/switch macros/
-s/A recipe for hosting backup documentation in case the package index is unavailable was provided/Sam provided a recipe for hosting backup documentation in case the package index is unavailable/
-s/An optimized implementation was suggested for fanout/Ben suggested an optimized implementation for fanout/
-s/An implementation for the prefix matching macro extensibility scheme was provided/Sam provided an implementation for the prefix matching macro extensibility scheme/
-s/The initial implementation was written/Sid wrote the initial implementation/
-s/The package was decomposed into lib\/test\/doc packages/Sid decomposed the package into lib\/test\/doc packages/
-s/The design of `feedback` was improved/Sid improved the design of `feedback`/
-s/The fancy-app PR was reviewed/Nia reviewed the fancy-app PR/
-s/fancy-app was restricted to just the fine-grained application form/Sid restricted fancy-app to just the fine-grained application form/
-s/The benchmarks were fixed according to the audit/Sid fixed the benchmarks according to the audit/
-s/Uses of deprecated macro form ~or were updated to ~or/Noah updated uses of deprecated macro form ~or to ~or/
-s/A quickscript for entering unicode in DrRacket was written/Stephen wrote a quickscript for entering unicode in DrRacket/
-s/fanout was modified to support arbitrary expressions for N and have an optimized implementation/Sid modified fanout to support arbitrary expressions for N and have an optimized implementation/
-s/An interactive tutorial was written using racket templates/Sid wrote an interactive tutorial using racket templates/
-s/The performance benchmarks were audited for accuracy/Michael did an audit of the performance benchmarks for accuracy/
-s/The PR improving the design of `feedback` was reviewed/Ben reviewed the PR improving the design of `feedback`/
-s/An early adopter advocated for the project (1)/Ben used and advocated for Qi/
-s/Documentation was written for Qi/Sid wrote docs for Qi/
-s/The ability to support the _ template in the function position was added/Noah added the ability to support the _ template in the function position/
-s/Some formatting and typos in the docs were fixed/Noah fixed some formatting and typos in the docs/
-s/A confusing error message in the threading form was reported and a way to handle it was suggested/Ben reported a confusing error message in the threading form and suggested a way to handle it/
-s/A Developer's Guide containing developer documentation was written/Sid wrote a Developer's Guide containing developer documentation/
-s/An early adopter advocated for the project (3)/Stephen used and advocated for Qi/
-s/These tools were used to identify and remove all heavy dependencies and dramatically reduce load-time latency/Ben used the tools to identify and remove all heavy dependencies and dramatically reduce load-time latency/
-s/Many options for proper macro extensibility were suggested/Michael suggested many options for proper macro extensibility/
-s/Some bugs in switch were fixed/Sid fixed some bugs in switch/
-s/The core macro was refactored into separate expansion and compilation stages/Michael and Sid refactored the core macro into separate expansion and compilation stages/
-s/The partition PR was reviewed/Sid reviewed the partition PR/
-s/The initial author gave a talk at RacketCon/Sid gave a talk at RacketCon/
-s/CI was set up for the project repository/Sid set up CI for the project repository/
-s/The benchmarks runner config was modified to avoid reporting success when it failed/Ben modified the benchmarks runner config to avoid reporting success when it failed/
-s/The Qi design challenge was organized/Sid organized the Qi design challenge/
-s/Improvements to the switch form were suggested/Jay suggested improvements to switch/
-s/Improvements were made to a Vim-oriented demo language to better support the Qi tutorial/Ben made improvements to a Vim plugin to better support the Qi tutorial/
-s/There was a suggestion to write a tutorial/Jesse and William suggested writing a tutorial/
-s/A flow-oriented debugger was added/Sid added a flow-oriented debugger/
-s/An elusive bug was identified that was causing performance degradation in the threading form/Nia identified an elusive bug causing performance degradation in the threading form/
-s/Some improvements were suggested to reduce memory consumption in building docs/Soegaard suggested some improvements to reduce memory consumption in building docs/
-s/A hygiene issue related to the same bug was identified that could have caused other bugs in the future/Michael identified a hygiene issue related to the same bug that could have caused other bugs in the future/
-s/Improvements to switch were implemented/Sid implemented improvements to switch/
-s/A Q&A was held after the talk/Jay led the Q&A for the talk/
-s/A dependency profiler tool was written to identify heavy dependencies/Bogdan wrote a dependency profiler tool to identify heavy dependencies/
-s/The idea of a Qi-themed event was suggested/Stephen suggested the idea of a Qi-themed event/
-s/The organization of some tests was improved/Noah improved the organization of some tests/
-s/The first library extending Qi functionality was written/Noah wrote the first library extending Qi functionality/
-s/Benchmarking scripts were added/Sid added benchmarking scripts/
-s/Technical support was provided to Qi users/Ben and Sid provided technical support to Qi users/
-s/A theoretical connection between Qi and Arrows in category theory was drawn./Sergiu drew a theoretical connection between Qi and Arrows in category theory./
-s/A simple macro extensibility based on prefix matching was designed, to allow users to extend the syntax of the language in a rudimentary way/Sid designed a simple macro extensibility based on prefix matching, to allow users to extend the syntax of the language in a rudimentary way/
-s/A script to measure load-time latency following that approach was written/Sid wrote a script to measure load-time latency following that approach/
-s/An illustrative example to motivate design improvements to the `feedback` form of the language was provided/1e1001 provided an illustrative example to motivate design improvements to the `feedback` form of the language/
-s/A design example was provided to motivate adding closures (the clos form) to Qi/Ben provided a design example to motivate adding closures (the clos form) to Qi/
-s/The performance of any?, all?, and none? were significantly improved/Noah significantly improved the performance of any?, all?, and none?/
-s/The backup docs workflow following the recipe was added/Sid added the backup docs workflow following Sam's recipe/
-s/There was a suggestion to restrict fancy-app's (a templatized function application library) scope in Qi to avoid tricky bugs in handling user input/Nia suggested restricting fancy-app's scope in Qi to avoid tricky bugs in handling user input/
-s/The load-time latency PR was reviewed/Ben reviewed the load-time latency PR/
-s/The first application leveraging Qi was written/Ben wrote the first application leveraging Qi/
-s/Support for keyword arguments to add bindings in lambda forms of the language was added/Noah added support for keyword arguments to add bindings in lambda forms of the language/
-s/There was a suggestion to use indirect documentation links to reduce build times/Sorawee and Jack suggested using indirect documentation links to reduce build times/
-s/The number of dependencies was reduced/Ben reduced the number of dependencies/
+s/Performance benchmarking was added to CI/[Sid] added performance benchmarking to CI/
+s/The wiki was created/[Sid] created a wiki/
+s/The name clos was suggested for this form/[Soegaard] suggested the name clos for this form/
+s/The fanout PR was reviewed/[Ben] reviewed the fanout PR/
+s/A way to measure load-time latency was suggested/[Sarna] suggested a way to measure load-time latency/
+s/"First class" macro extensibility was implemented, allowing users to seamlessly extend the syntax of the language/[Michael, Sid] implemented "first class" macro extensibility (based on Michael et al's paper), allowing users to seamlessly extend the syntax of the language/
+s/The clos form was implemented/[Sid] implemented the clos form/
+s/An early adopter advocated for the project (2)/[Cassie] used and advocated for Qi/
+s/The language was designed/[Sid] designed the language/
+s/There was a suggestion to distribute a Qi template using racket templates/[Stephen] suggested distributing a Qi template using racket templates/
+s/The partition implementation was optimized/[Ben] optimized the partition implementation/
+s/The suggested error message fix was implemented/[Sid] implemented Ben's suggested error message fix/
+s/partition was added, which is a generalized version of the sieve form/[Ben] added partition, a generalized version of the sieve form/
+s/There was a suggestion to create a wiki for Qi/[Anonymous] suggested creating a wiki for Qi/
+s/There was a suggestion to decompose the package into lib\/test\/doc packages for more flexible development and distribution/[Stephen] suggested decomposing the package into lib\/test\/doc packages for more flexible development and distribution/
+s/A weekly meetup for the project was started/[Michael, Sid] started a weekly meetup for the project/
+s/It was pointed out that fanout does not accept arbitrary Racket expressions for N/[Ben] pointed out that fanout does not accept arbitrary Racket expressions for N/
+s/Advent of Code was solved using Qi/[Ben] solved Advent of Code using Qi/
+s/The initial author received expert feedback on drafts of the talk/[Jay] gave feedback on Sid's talk/
+s/A quickscript for interactive evaluation in DrRacket was added to support the Qi tutorial/[Laurent] added a quickscript for interactive evaluation in DrRacket to support the Qi tutorial/
+s/A broken link in the documentation was reported/[Stephen] reported a broken link in the documentation/
+s/The package config was modified so that Qi appears in the languages section of the docs/[Stephen] modified the package config so that Qi appears in the languages section of the docs/
+s/The repo was migrated to an organization account/[Sid] migrated the repo to an organization account/
+s/An installation issue was reported/[jo-sm] reported an installation issue/
+s/The initial author was invited to give a talk at RacketCon/[Sid] was invited to give a talk at RacketCon/
+s/The unused let\/flow and let\/switch macros were removed/[Noah] removed the unused let\/flow and let\/switch macros/
+s/A recipe for hosting backup documentation in case the package index is unavailable was provided/[Sam] provided a recipe for hosting backup documentation in case the package index is unavailable/
+s/An optimized implementation was suggested for fanout/[Ben] suggested an optimized implementation for fanout/
+s/An implementation for the prefix matching macro extensibility scheme was provided/[Sam] provided an implementation for the prefix matching macro extensibility scheme/
+s/The initial implementation was written/[Sid] wrote the initial implementation/
+s/The package was decomposed into lib\/test\/doc packages/[Sid] decomposed the package into lib\/test\/doc packages/
+s/The design of `feedback` was improved/[Sid] improved the design of `feedback`/
+s/The fancy-app PR was reviewed/[Nia] reviewed the fancy-app PR/
+s/fancy-app was restricted to just the fine-grained application form/[Sid] restricted fancy-app to just the fine-grained application form/
+s/The benchmarks were fixed according to the audit/[Sid] fixed the benchmarks according to the audit/
+s/Uses of deprecated macro form ~or were updated to ~or/[Noah] updated uses of deprecated macro form ~or to ~or/
+s/A quickscript for entering unicode in DrRacket was written/[Stephen] wrote a quickscript for entering unicode in DrRacket/
+s/fanout was modified to support arbitrary expressions for N and have an optimized implementation/[Sid] modified fanout to support arbitrary expressions for N and have an optimized implementation/
+s/An interactive tutorial was written using racket templates/[Sid] wrote an interactive tutorial using racket templates/
+s/The performance benchmarks were audited for accuracy/[Michael] did an audit of the performance benchmarks for accuracy/
+s/The PR improving the design of `feedback` was reviewed/[Ben] reviewed the PR improving the design of `feedback`/
+s/An early adopter advocated for the project (1)/[Ben] used and advocated for Qi/
+s/Documentation was written for Qi/[Sid] wrote docs for Qi/
+s/The ability to support the _ template in the function position was added/[Noah] added the ability to support the _ template in the function position/
+s/Some formatting and typos in the docs were fixed/[Noah] fixed some formatting and typos in the docs/
+s/A confusing error message in the threading form was reported and a way to handle it was suggested/[Ben] reported a confusing error message in the threading form and suggested a way to handle it/
+s/A Developer's Guide containing developer documentation was written/[Sid] wrote a Developer's Guide containing developer documentation/
+s/An early adopter advocated for the project (3)/[Stephen] used and advocated for Qi/
+s/These tools were used to identify and remove all heavy dependencies and dramatically reduce load-time latency/[Ben] used the tools to identify and remove all heavy dependencies and dramatically reduce load-time latency/
+s/Many options for proper macro extensibility were suggested/[Michael] suggested many options for proper macro extensibility/
+s/Some bugs in switch were fixed/[Sid] fixed some bugs in switch/
+s/The core macro was refactored into separate expansion and compilation stages/[Michael, Sid] refactored the core macro into separate expansion and compilation stages/
+s/The partition PR was reviewed/[Sid] reviewed the partition PR/
+s/The initial author gave a talk at RacketCon/[Sid] gave a talk at RacketCon/
+s/CI was set up for the project repository/[Sid] set up CI for the project repository/
+s/The benchmarks runner config was modified to avoid reporting success when it failed/[Ben] modified the benchmarks runner config to avoid reporting success when it failed/
+s/The Qi design challenge was organized/[Sid] organized the Qi design challenge/
+s/Improvements to the switch form were suggested/[Jay] suggested improvements to switch/
+s/Improvements were made to a Vim-oriented demo language to better support the Qi tutorial/[Ben] made improvements to a Vim plugin to better support the Qi tutorial/
+s/There was a suggestion to write a tutorial/[Jesse, William] suggested writing a tutorial/
+s/A flow-oriented debugger was added/[Sid] added a flow-oriented debugger/
+s/An elusive bug was identified that was causing performance degradation in the threading form/[Nia] identified an elusive bug causing performance degradation in the threading form/
+s/Some improvements were suggested to reduce memory consumption in building docs/[Soegaard] suggested some improvements to reduce memory consumption in building docs/
+s/A hygiene issue related to the same bug was identified that could have caused other bugs in the future/[Michael] identified a hygiene issue related to the same bug that could have caused other bugs in the future/
+s/Improvements to switch were implemented/[Sid] implemented improvements to switch/
+s/A Q&A was held after the talk/[Jay] led the Q&A for the talk/
+s/A dependency profiler tool was written to identify heavy dependencies/[Bogdan] wrote a dependency profiler tool to identify heavy dependencies/
+s/The idea of a Qi-themed event was suggested/[Stephen] suggested the idea of a Qi-themed event/
+s/The organization of some tests was improved/[Noah] improved the organization of some tests/
+s/The first library extending Qi functionality was written/[Noah] wrote the first library extending Qi functionality/
+s/Benchmarking scripts were added/[Sid] added benchmarking scripts/
+s/Technical support was provided to Qi users/[Ben, Sid] provided technical support to Qi users/
+s/A theoretical connection between Qi and Arrows in category theory was drawn./[Sergiu] drew a theoretical connection between Qi and Arrows in category theory./
+s/A simple macro extensibility based on prefix matching was designed, to allow users to extend the syntax of the language in a rudimentary way/[Sid] designed a simple macro extensibility based on prefix matching, to allow users to extend the syntax of the language in a rudimentary way/
+s/A script to measure load-time latency following that approach was written/[Sid] wrote a script to measure load-time latency following that approach/
+s/An illustrative example to motivate design improvements to the `feedback` form of the language was provided/[1e1001] provided an illustrative example to motivate design improvements to the `feedback` form of the language/
+s/A design example was provided to motivate adding closures (the clos form) to Qi/[Ben] provided a design example to motivate adding closures (the clos form) to Qi/
+s/The performance of any?, all?, and none? were significantly improved/[Noah] significantly improved the performance of any?, all?, and none?/
+s/The backup docs workflow following the recipe was added/[Sid] added the backup docs workflow following Sam's recipe/
+s/There was a suggestion to restrict fancy-app's (a templatized function application library) scope in Qi to avoid tricky bugs in handling user input/[Nia] suggested restricting fancy-app's scope in Qi to avoid tricky bugs in handling user input/
+s/The load-time latency PR was reviewed/[Ben] reviewed the load-time latency PR/
+s/The first application leveraging Qi was written/[Ben] wrote the first application leveraging Qi/
+s/Support for keyword arguments to add bindings in lambda forms of the language was added/[Noah] added support for keyword arguments to add bindings in lambda forms of the language/
+s/There was a suggestion to use indirect documentation links to reduce build times/[Sorawee, Jack] suggested using indirect documentation links to reduce build times/
+s/The number of dependencies was reduced/[Ben] reduced the number of dependencies/
diff --git i/evaluation/appraisal/ideas.md w/evaluation/appraisal/ideas.md
index c97a66d..addd166 100644
--- i/evaluation/appraisal/ideas.md
+++ w/evaluation/appraisal/ideas.md
@@ -1,3 +1,5 @@
+#lang abe/ideas2 ideas
+
 * Qi [100%]
   * DSL [90%]
     * syntax [25%]
diff --git i/evaluation/attribution/synthesis.rkt w/evaluation/attribution/synthesis.rkt
index d128ebe..75bb021 100644
--- i/evaluation/attribution/synthesis.rkt
+++ w/evaluation/attribution/synthesis.rkt
@@ -2,9 +2,9 @@
 
 (require abe/dia
          qi
-         "capital.rkt"
-         "labor.rkt"
-         "ideas.rkt")
+         "../appraisal/deanonymized/capital.md"
+         "../appraisal/deanonymized/labor.md"
+         "../antecedents/ideas.md")
 
 (define attributions (make-hash))
 
diff --git i/input/capital.md w/input/capital.md
index 84bba70..15c4c37 100644
--- i/input/capital.md
+++ w/input/capital.md
@@ -1,11 +1,11 @@
-* Racket
-* rackunit
-* cover
-* cover-coveralls
-* typed-stack
-* mischief
-* adjutor
-* relation
-* racket-collections
-* metapict
-* greg-racket-makefile : Greg's Makefile for Racket projects
+* [Racket]
+* [rackunit]
+* [cover]
+* [cover-coveralls]
+* [typed-stack]
+* [mischief]
+* [adjutor]
+* [relation]
+* [racket-collections]
+* [metapict]
+* [greg-racket-makefile] Greg's Makefile for Racket projects
diff --git i/input/labor.md w/input/labor.md
index e8186de..fafdfa6 100644
--- i/input/labor.md
+++ w/input/labor.md
@@ -1,85 +1,85 @@
-* Sid designed the language
-* Sid wrote the initial implementation
-* Sid was invited to give a talk at RacketCon
-* Jay gave feedback on Sid's talk
-* Sid gave a talk at RacketCon
-* Jay led the Q&A for the talk
-* Jay suggested improvements to switch
-* Sid implemented improvements to switch
-* Ben used and advocated for Qi
-* Cassie used and advocated for Qi
-* Stephen used and advocated for Qi
-* Ben solved Advent of Code using Qi
-* Ben provided a design example to motivate adding closures (the clos form) to Qi
-* Soegaard suggested the name clos for this form
-* Sid implemented the clos form
-* Jesse and William suggested writing a tutorial
-* Stephen wrote a quickscript for entering unicode in DrRacket
-* Stephen suggested distributing a Qi template using racket templates
-* Sid wrote an interactive tutorial using racket templates
-* Laurent added a quickscript for interactive evaluation in DrRacket to support the Qi tutorial
-* Ben made improvements to a Vim plugin to better support the Qi tutorial
-* Stephen suggested decomposing the package into lib/test/doc packages for more flexible development and distribution
-* Sid decomposed the package into lib/test/doc packages
-* Sid added a flow-oriented debugger
-* jo-sm reported an installation issue
-* Stephen reported a broken link in the documentation
-* Sid fixed some bugs in switch
-* Sid designed a simple macro extensibility based on prefix matching, to allow users to extend the syntax of the language in a rudimentary way
-* Sam provided an implementation for the prefix matching macro extensibility scheme
-* Michael suggested many options for proper macro extensibility
-* Michael and Sid implemented "first class" macro extensibility (based on Michael et al's paper), allowing users to seamlessly extend the syntax of the language
-* Ben reported a confusing error message in the threading form and suggested a way to handle it
-* Sid implemented Ben's suggested error message fix
-* Sergiu drew a theoretical connection between Qi and Arrows in category theory.
-* Stephen suggested the idea of a Qi-themed event
-* Sid organized the Qi design challenge
-* 1e1001 provided an illustrative example to motivate design improvements to the `feedback` form of the language
-* Sid improved the design of `feedback`
-* Ben reviewed the PR improving the design of `feedback`
-* Nia suggested restricting fancy-app's scope in Qi to avoid tricky bugs in handling user input
-* Sid restricted fancy-app to just the fine-grained application form
-* Nia reviewed the fancy-app PR
-* Ben pointed out that fanout does not accept arbitrary Racket expressions for N
-* Ben suggested an optimized implementation for fanout
-* Sid modified fanout to support arbitrary expressions for N and have an optimized implementation
-* Ben reviewed the fanout PR
-* Ben added partition, a generalized version of the sieve form
-* Ben optimized the partition implementation
-* Sid reviewed the partition PR
-* Stephen modified the package config so that Qi appears in the languages section of the docs
-* Sid set up CI for the project repository
-* Sam provided a recipe for hosting backup documentation in case the package index is unavailable
-* Sid added the backup docs workflow following Sam's recipe
-* Sid added benchmarking scripts
-* Sid added performance benchmarking to CI
-* Michael did an audit of the performance benchmarks for accuracy
-* Sid fixed the benchmarks according to the audit
-* Michael and Sid refactored the core macro into separate expansion and compilation stages
-* Nia identified an elusive bug causing performance degradation in the threading form
-* Michael identified a hygiene issue related to the same bug that could have caused other bugs in the future
-* Ben reduced the number of dependencies
-* Bogdan wrote a dependency profiler tool to identify heavy dependencies
-* Sarna suggested a way to measure load-time latency
-* Sid wrote a script to measure load-time latency following that approach
-* Ben reviewed the load-time latency PR
-* Ben used the tools to identify and remove all heavy dependencies and dramatically reduce load-time latency
-* Ben modified the benchmarks runner config to avoid reporting success when it failed
-* Sorawee and Jack suggested using indirect documentation links to reduce build times
-* Soegaard suggested some improvements to reduce memory consumption in building docs
-* Noah added the ability to support the _ template in the function position
-* Noah added support for keyword arguments to add bindings in lambda forms of the language
-* Noah fixed some formatting and typos in the docs
-* Noah updated uses of deprecated macro form ~or to ~or*
-* Noah removed the unused let/flow and let/switch macros
-* Noah improved the organization of some tests
-* Noah significantly improved the performance of any?, all?, and none?
-* Noah wrote the first library extending Qi functionality
-* Ben wrote the first application leveraging Qi
-* Anonymous suggested creating a wiki for Qi
-* Sid created a wiki
-* Sid wrote a Developer's Guide containing developer documentation
-* Sid wrote docs for Qi
-* Michael and Sid started a weekly meetup for the project
-* Sid migrated the repo to an organization account
-* Ben and Sid provided technical support to Qi users
+* [Sid] designed the language
+* [Sid] wrote the initial implementation
+* [Sid] was invited to give a talk at RacketCon
+* [Jay] gave feedback on Sid's talk
+* [Sid] gave a talk at RacketCon
+* [Jay] led the Q&A for the talk
+* [Jay] suggested improvements to switch
+* [Sid] implemented improvements to switch
+* [Ben] used and advocated for Qi
+* [Cassie] used and advocated for Qi
+* [Stephen] used and advocated for Qi
+* [Ben] solved Advent of Code using Qi
+* [Ben] provided a design example to motivate adding closures (the clos form) to Qi
+* [Soegaard] suggested the name clos for this form
+* [Sid] implemented the clos form
+* [Jesse, William] suggested writing a tutorial
+* [Stephen] wrote a quickscript for entering unicode in DrRacket
+* [Stephen] suggested distributing a Qi template using racket templates
+* [Sid] wrote an interactive tutorial using racket templates
+* [Laurent] added a quickscript for interactive evaluation in DrRacket to support the Qi tutorial
+* [Ben] made improvements to a Vim plugin to better support the Qi tutorial
+* [Stephen] suggested decomposing the package into lib/test/doc packages for more flexible development and distribution
+* [Sid] decomposed the package into lib/test/doc packages
+* [Sid] added a flow-oriented debugger
+* [jo-sm] reported an installation issue
+* [Stephen] reported a broken link in the documentation
+* [Sid] fixed some bugs in switch
+* [Sid] designed a simple macro extensibility based on prefix matching, to allow users to extend the syntax of the language in a rudimentary way
+* [Sam] provided an implementation for the prefix matching macro extensibility scheme
+* [Michael] suggested many options for proper macro extensibility
+* [Michael, Sid] implemented "first class" macro extensibility (based on Michael et al's paper), allowing users to seamlessly extend the syntax of the language
+* [Ben] reported a confusing error message in the threading form and suggested a way to handle it
+* [Sid] implemented Ben's suggested error message fix
+* [Sergiu] drew a theoretical connection between Qi and Arrows in category theory.
+* [Stephen] suggested the idea of a Qi-themed event
+* [Sid] organized the Qi design challenge
+* [1e1001] provided an illustrative example to motivate design improvements to the `feedback` form of the language
+* [Sid] improved the design of `feedback`
+* [Ben] reviewed the PR improving the design of `feedback`
+* [Nia] suggested restricting fancy-app's scope in Qi to avoid tricky bugs in handling user input
+* [Sid] restricted fancy-app to just the fine-grained application form
+* [Nia] reviewed the fancy-app PR
+* [Ben] pointed out that fanout does not accept arbitrary Racket expressions for N
+* [Ben] suggested an optimized implementation for fanout
+* [Sid] modified fanout to support arbitrary expressions for N and have an optimized implementation
+* [Ben] reviewed the fanout PR
+* [Ben] added partition, a generalized version of the sieve form
+* [Ben] optimized the partition implementation
+* [Sid] reviewed the partition PR
+* [Stephen] modified the package config so that Qi appears in the languages section of the docs
+* [Sid] set up CI for the project repository
+* [Sam] provided a recipe for hosting backup documentation in case the package index is unavailable
+* [Sid] added the backup docs workflow following Sam's recipe
+* [Sid] added benchmarking scripts
+* [Sid] added performance benchmarking to CI
+* [Michael] did an audit of the performance benchmarks for accuracy
+* [Sid] fixed the benchmarks according to the audit
+* [Michael, Sid] refactored the core macro into separate expansion and compilation stages
+* [Nia] identified an elusive bug causing performance degradation in the threading form
+* [Michael] identified a hygiene issue related to the same bug that could have caused other bugs in the future
+* [Ben] reduced the number of dependencies
+* [Bogdan] wrote a dependency profiler tool to identify heavy dependencies
+* [Sarna] suggested a way to measure load-time latency
+* [Sid] wrote a script to measure load-time latency following that approach
+* [Ben] reviewed the load-time latency PR
+* [Ben] used the tools to identify and remove all heavy dependencies and dramatically reduce load-time latency
+* [Ben] modified the benchmarks runner config to avoid reporting success when it failed
+* [Sorawee, Jack] suggested using indirect documentation links to reduce build times
+* [Soegaard] suggested some improvements to reduce memory consumption in building docs
+* [Noah] added the ability to support the _ template in the function position
+* [Noah] added support for keyword arguments to add bindings in lambda forms of the language
+* [Noah] fixed some formatting and typos in the docs
+* [Noah] updated uses of deprecated macro form ~or to ~or*
+* [Noah] removed the unused let/flow and let/switch macros
+* [Noah] improved the organization of some tests
+* [Noah] significantly improved the performance of any?, all?, and none?
+* [Noah] wrote the first library extending Qi functionality
+* [Ben] wrote the first application leveraging Qi
+* [Anonymous] suggested creating a wiki for Qi
+* [Sid] created a wiki
+* [Sid] wrote a Developer's Guide containing developer documentation
+* [Sid] wrote docs for Qi
+* [Michael, Sid] started a weekly meetup for the project
+* [Sid] migrated the repo to an organization account
+* [Ben, Sid] provided technical support to Qi users
```

</details>