### PR TITLE
Spell out initial use of DIA acronym in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docs](https://img.shields.io/badge/docs-dia-blue)](https://drym-org.github.io/dia/)
 
-# DIA Resources
+# Dialectical Inheritance Attribution (DIA) Resources
 
 ## Installation
 


### PR DESCRIPTION
I came here after seeing your "Redeeming Open Source" talk, and noticed that "DIA" was used, but "Dialectical Inheritance Attribution" wasn't used anywhere.